### PR TITLE
Config updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
   "vulnerabilityAlerts": {
     "labels": ["security"]
   },
+  "timezone": "America/New_York",
+  "schedule": [
+    "schedule:earlyMondays"
+  ],
   "docker": {
     "pinDigests": true,
     "semanticCommitType": "build"
@@ -26,7 +30,11 @@
       "packagePatterns": ["node"],
       "groupName": "node",
       "semanticCommitScope": "docker",
-      "allowedVersions": "^10.15"
+      "allowedVersions": "^10.15",
+      "schedule": [
+        "before 2am on monday",
+        "before 2am on thursday"
+      ]
     },
     {
       "packagePatterns": ["newrelic"],

--- a/renovate.json
+++ b/renovate.json
@@ -29,9 +29,16 @@
       "allowedVersions": "^10.15"
     },
     {
-      "packagePatterns": ["newrelic", "metrics-client"],
-      "groupName": "metrics",
+      "packagePatterns": ["newrelic"],
+      "groupName": "newrelic metrics",
       "allowedVersions": ">5.2",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "packagePatterns": ["metrics-client"],
+      "groupName": "metrics-client",
+      "allowedVersions": ">4.0",
       "automerge": true,
       "automergeType": "branch"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,6 @@
   "vulnerabilityAlerts": {
     "labels": ["security"]
   },
-  "timezone": "America/New_York",
-  "schedule": [
-    "schedule:earlyMondays"
-  ],
   "docker": {
     "pinDigests": true,
     "semanticCommitType": "build"
@@ -30,11 +26,7 @@
       "packagePatterns": ["node"],
       "groupName": "node",
       "semanticCommitScope": "docker",
-      "allowedVersions": "^10.15",
-      "schedule": [
-        "before 2am on monday",
-        "before 2am on thursday"
-      ]
+      "allowedVersions": "^10.15"
     },
     {
       "packagePatterns": ["newrelic"],
@@ -44,9 +36,9 @@
       "automergeType": "branch"
     },
     {
-      "packagePatterns": ["metrics-client"],
+      "packageNames": ["@pager/metrics-client"],
       "groupName": "metrics-client",
-      "allowedVersions": ">4.0",
+      "allowedVersions": ">=4.2.1",
       "automerge": true,
       "automergeType": "branch"
     },
@@ -56,16 +48,16 @@
     },
     {
       "packagePatterns": ["^eslint"],
-      "groupName": "eslint packages",
+      "groupName": "linters",
       "automerge": true
     },
     {
       "packageNames": ["hapi", "boom", "good", "joi", "hoek", "wreck"],
-      "groupName": "hapi w/o module namespace"
+      "groupName": "hapi legacy"
     },
     {
       "packagePatterns": ["^@hapi/"],
-      "groupName": "hapi w/ module namespace",
+      "groupName": "hapi",
       "excludePackageNames": ["@hapi/lab", "@hapi/code"]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -47,8 +47,8 @@
       "groupName": "testing"
     },
     {
-      "packagePatterns": ["eslint"],
-      "groupName": "linters",
+      "packagePatterns": ["^eslint"],
+      "groupName": "eslint packages",
       "automerge": true
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
       "automergeType": "branch"
     },
     {
-      "packageNames": ["lab", "code", "sinon", "mocha"],
+      "packageNames": ["lab", "code", "@hapi/lab", "@hapi/code", "sinon", "mocha"],
       "groupName": "testing"
     },
     {
@@ -52,8 +52,13 @@
       "automerge": true
     },
     {
-      "packageNames": ["hapi", "boom", "joi", "hoek", "wreck"],
-      "groupName": "hapi"
+      "packageNames": ["hapi", "boom", "good", "joi", "hoek", "wreck"],
+      "groupName": "hapi w/o module namespace"
+    },
+    {
+      "packagePatterns": ["^@hapi/"],
+      "groupName": "hapi w/ module namespace",
+      "excludePackageNames": ["@hapi/lab", "@hapi/code"]
     }
   ]
 }


### PR DESCRIPTION
What we can do also:

1. Set [bumpVersion](https://renovatebot.com/docs/configuration-options/#bumpversion). Yes, we might have `x.x.130` version, but it would be semantically valid.
2. Set [prConcurrentLimit](https://renovatebot.com/docs/configuration-options/#prconcurrentlimit) to increase renovate PRs count. We won't be able to estimate the scale of the disaster by opened PRs count, but it would be useful for CI. Now set to 20 in [config:base](https://github.com/renovatebot/presets/blob/dda2282e5a53982daea09489d622eedc174243e2/packages/renovate-config-config/package.json#L31)