### PR TITLE
Automerge digests when tests pass

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    "docker:enableMajor"
+    "docker:enableMajor",
+    "default:automergeDigest"
   ],
   "semanticCommitScope": "deps",
   "labels": ["chore"],


### PR DESCRIPTION
Automates this kinds of PRs to reduce noise while making sure version doesn't break builds: 
- https://github.com/pagerinc/api-demographics/pull/106
- https://github.com/pagerinc/event-sourcerer-client/pull/17

Ref: https://docs.renovatebot.com/docker/

Related: https://renovatebot.com/blog/docker-mutable-tags