### PR TITLE
chore: update max Node version to 12

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       "packagePatterns": ["node"],
       "groupName": "node",
       "semanticCommitScope": "docker",
-      "allowedVersions": "^10.15"
+      "allowedVersions": "^12.13"
     },
     {
       "packagePatterns": ["newrelic"],


### PR DESCRIPTION
### Why
After this change, Renovate will create PRs across all our Renovate-enabled repos to upgrade Node to 12. We'll be able to see at-a-glance whether tests pass, and deploy those PR's to dev to test further if necessary.