### PR TITLE
chore: clean infra config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,0 @@
-version: "2"
-plugins:
-  eslint:
-    enabled: true
-    channel: "eslint-5"
-  fixme:
-    enabled: true
-  markdownlint:
-    enabled: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,0 @@
-extends: standard

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "docker:enableMajor",
     "default:automergeDigest"
   ],
+  "branchPrefix": "renovate-",
   "semanticCommitScope": "deps",
   "labels": ["chore"],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "docker:enableMajor",
     "default:automergeDigest"
   ],
-  "branchPrefix": "renovate-",
+  "branchPrefix": "renovate_",
   "semanticCommitScope": "deps",
   "labels": ["chore"],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,50 +16,14 @@
   "docker-compose": {
     "digest": {
       "enabled": false
-    }
+    },
+    "pinDigests": false
   },
   "packageRules": [
     {
-      "depTypeList": ["dependencies"],
-      "semanticCommitType": "build"
-    },
-    {
       "packagePatterns": ["node"],
       "groupName": "node",
-      "semanticCommitScope": "docker",
-      "allowedVersions": "^12.13"
-    },
-    {
-      "packagePatterns": ["newrelic"],
-      "groupName": "newrelic metrics",
-      "allowedVersions": ">5.2",
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "packageNames": ["@pager/metrics-client"],
-      "groupName": "metrics-client",
-      "allowedVersions": ">=4.3",
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "packageNames": ["lab", "code", "@hapi/lab", "@hapi/code", "sinon", "mocha"],
-      "groupName": "testing"
-    },
-    {
-      "packagePatterns": ["^eslint"],
-      "groupName": "linters",
-      "automerge": true
-    },
-    {
-      "packageNames": ["hapi", "boom", "good", "joi", "hoek", "wreck"],
-      "groupName": "hapi legacy"
-    },
-    {
-      "packagePatterns": ["^@hapi/"],
-      "groupName": "hapi",
-      "excludePackageNames": ["@hapi/lab", "@hapi/code"]
+      "semanticCommitScope": "docker"
     }
   ]
 }


### PR DESCRIPTION
This moves packages related to renovate config to keep this infra related.

Ref https://github.com/pagerinc/renovate-config/pull/12