### PR TITLE
feat: amazing new config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "branchPrefix": "renovate_",
   "semanticCommitScope": "deps",
   "labels": ["chore"],
+  "schedule": ["after 6pm and before 8am on every weekday", "every weekend"],
   "prCreation": "not-pending",
   "stabilityDays": 1,
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,8 @@
   "branchPrefix": "renovate_",
   "semanticCommitScope": "deps",
   "labels": ["chore"],
+  "prCreation": "not-pending",
+  "stabilityDays": 1,
   "vulnerabilityAlerts": {
     "labels": ["security"]
   },
@@ -20,12 +22,33 @@
     },
     "pinDigests": false
   },
+  "node": {
+    "supportPolicy": ["lts_latest"],
+    "semanticCommitScope": "docker",
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "packageRules": [
     {
-      "packagePatterns": ["node"],
-      "groupName": "node",
-      "allowedVersions": "^12.14",
-      "semanticCommitScope": "docker"
+      "packageNames": ["postgres"],
+      "allowedVersions": "^9.6",
+      "semanticCommitScope": "docker",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "packageNames": ["redis"],
+      "allowedVersions": "^4",
+      "semanticCommitScope": "docker",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "packageNames": ["rabbitmq"],
+      "allowedVersions": "^3.8",
+      "semanticCommitScope": "docker",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
- Add schedule (less noise, less rebases in our PRs)
- Create PR once checks are completed (we can take immediate action)
- Allow 1 day for stability before creating PRs for major update
- Better latest LTS policy for node
- Only use our semver ranges for postgres, redis and rabbitmq